### PR TITLE
Fix all fatal compilation errors with compiler warnings set to all in…

### DIFF
--- a/TFT_eSPI_ms/TFT_eSPI.cpp
+++ b/TFT_eSPI_ms/TFT_eSPI.cpp
@@ -1243,7 +1243,6 @@ void TFT_eSPI::pushImage(int32_t x, int32_t y, uint32_t w, uint32_t h, uint8_t *
           //else     drawPixel((dw-len)+xp,h-dh,bitmap_bg);
           xp++;
         }
-        *ptr++;
         len -= 8;
       }
 
@@ -1392,7 +1391,6 @@ void TFT_eSPI::pushImage(int32_t x, int32_t y, uint32_t w, uint32_t h, uint8_t *
           px++;
           xp++;
         }
-        *ptr++;
         len -= 8;
       }
       if (np) pushColor(bitmap_fg, np);

--- a/menu_file.cpp
+++ b/menu_file.cpp
@@ -360,8 +360,7 @@ boolean sdMoveUp() {
 
 
 void closeAllFiles() {
-  uint8_t i = 0 ;
-  for (i ; i < DIR_LEVEL_MAX ; i++ ) {
+  for (uint8_t i = 0; i < DIR_LEVEL_MAX ; i++ ) {
     aDir[i].close() ;
   }
   //memset(workDirParents , 0 , sizeof(workDirParents)) ;

--- a/nunchuk.cpp
+++ b/nunchuk.cpp
@@ -179,7 +179,7 @@ void handleNunchuk (void) {
             } 
           }
           //if ( (machineStatus[0] == 'J' ) && ( ( prevMoveX != moveX) || ( prevMoveY != moveY)  || ( prevMoveZ != moveZ) ) ) { // cancel Jog if jogging and t least one direction change 
-          if ( (machineStatus[0] == 'J' || machineStatus[0] == 'I' ) && ( ( prevMoveX != moveX) || ( prevMoveY != moveY)  || ( prevMoveZ != moveZ) ) ||  ( prevMoveA != moveA) ) { // cancel Jog if jogging and at least one direction change       
+      if ( (machineStatus[0] == 'J' || machineStatus[0] == 'I' ) && ( prevMoveX != moveX || prevMoveY != moveY  || prevMoveZ != moveZ || prevMoveA != moveA) ) { // cancel Jog if jogging and at least one direction change       
             jogCancelFlag = true ; 
             cntSameMove = 0 ;             // reset the counter
             //Serial.println("cancel jog") ;


### PR DESCRIPTION
… preferences

Fix all compilation errors when all warnings set:

1) menu_file.cpp: In function 'void closeAllFiles()':
menu_file.cpp:364:10: error: statement has no effect [-Werror=unused-value]
   for (i ; i < DIR_LEVEL_MAX ; i++ ) {
          ^exit status 1
statement has no effect [-Werror=unused-value]

2) nunchuk.cpp: In function 'void handleNunchuk()':
nunchuk.cpp:183:70: error: suggest parentheses around '&&' within '||' [-Werror=parentheses]
           if ( (machineStatus[0] == 'J' || machineStatus[0] == 'I' ) && ( ( prevMoveX != moveX) || ( prevMoveY != moveY)  || ( prevMoveZ != moveZ) ) ||  ( prevMoveA != moveA) ) { // cancel Jog if jogging and at least one direction change

cc1plus.exe: some warnings being treated as errors
exit status 1
suggest parentheses around '&&' within '||' [-Werror=parentheses]

3) TFT_eSPI.cpp: In member function 'void TFT_eSPI::pushImage(int32_t, int32_t, uint32_t, uint32_t, uint8_t*, bool)':
TFT_eSPI.cpp:1246:15: error: value computed is not used [-Werror=unused-value]
         *ptr++;
               ^
TFT_eSPI.cpp: In member function 'void TFT_eSPI::pushImage(int32_t, int32_t, uint32_t, uint32_t, uint8_t*, uint8_t, bool)':
TFT_eSPI.cpp:1395:15: error: value computed is not used [-Werror=unused-value]
         *ptr++;
               ^
cc1plus.exe: some warnings being treated as errors
exit status 1
Error compiling for board ESP32 Dev Module.

*p++ is going to be grouped as *(p++), so not used as uint8_t* ptr = data
lines can be removed.