### PR TITLE
Fixed tools menu not working (error 22 feed rate not defined)

### DIFF
--- a/grbl_controller_esp32/actions.cpp
+++ b/grbl_controller_esp32/actions.cpp
@@ -134,12 +134,12 @@ void fReset(uint8_t param) {
 }
 
 void fCancel(uint8_t param) {
-  if( statusPrinting == PRINTING_FROM_SD || statusPrinting == PRINTING_PAUSED   ) {
+  if( statusPrinting == PRINTING_FROM_SD || statusPrinting == PRINTING_PAUSED || statusPrinting == PRINTING_CMD || statusPrinting == PRINTING_STRING) {
     statusPrinting = PRINTING_STOPPED ;
     closeFileToRead() ;    
     toGrbl( (char) SOFT_RESET) ;
     //Serial2.print( (char) SOFT_RESET) ;
-  }  
+  } 
   currentPage = _P_INFO ;  // go to page Info
   updateFullPage = true ;  // force a redraw even if current page does not change
   waitReleased = true ;          // discard "pressed" until a release 


### PR DESCRIPTION
- Fixed error 22 from tools menu strings that contained spaces as their first character (following \n). This was badly handled by GRBL (it's possible to reproduce this by sending commands like " $G" (note the space in from of $G). This also triggers error 22.
- Also fixed waitOk. In some situations the ok string has 4 characters (probably ok\n\r). Those were not considered valid.
