### PR TITLE
Update setupTxt.cpp

### DIFF
--- a/grbl_controller_esp32/setupTxt.cpp
+++ b/grbl_controller_esp32/setupTxt.cpp
@@ -1,6 +1,6 @@
 
-#include "setupTxt.h"
 #include "config.h"
+#include "setupTxt.h"
 #include "language.h"
 #include "SdFat.h"
 #include "FS.h"


### PR DESCRIPTION
Config.h must be included before setupTxt.h because of declaration of POS_OF_MOVE_D_AUTO. Fix an issue in drawing buttons in XYZA configuration on move page.